### PR TITLE
Sync startup rig footer and refresh README

### DIFF
--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -429,6 +429,8 @@ NeuralAmpModeler::NeuralAmpModeler(const InstanceInfo& info)
     // Footer
     const IRECT footerArea(mainL, toggleY + toggleH + 6.f, mainR, toggleY + toggleH + 6.f + footerH);
     pGraphics->AttachControl(new VoLumFooterControl(footerArea), kCtrlTagVoLumFooter);
+    if (!mVolumLastLoadedFile.empty())
+      pGraphics->GetControlWithTag(kCtrlTagVoLumFooter)->As<VoLumFooterControl>()->SetText(mVolumLastLoadedFile.c_str());
 
     // Settings gear button (top-right of main panel)
     {
@@ -1317,10 +1319,17 @@ void NeuralAmpModeler::_VolumRefreshChannels()
   if (mVolumChannelIdx >= (int)mVolumChannelFiles.size())
     mVolumChannelIdx = 0;
 
+  if (!mVolumChannelFiles.empty() && mVolumChannelIdx >= 0 && mVolumChannelIdx < (int)mVolumChannelFiles.size())
+    mVolumLastLoadedFile = std::filesystem::path(mVolumChannelFiles[mVolumChannelIdx]).filename().string();
+  else
+    mVolumLastLoadedFile.clear();
+
   if (auto* pGfx = GetUI())
   {
     if (auto* stepper = pGfx->GetControlWithTag(kCtrlTagVoLumChannelStep))
       stepper->As<VoLumChannelStepControl>()->SetChannels(mVolumChannelLabels, mVolumChannelIdx);
+    if (auto* footer = pGfx->GetControlWithTag(kCtrlTagVoLumFooter))
+      footer->As<VoLumFooterControl>()->SetText(mVolumLastLoadedFile.empty() ? "(no rig loaded)" : mVolumLastLoadedFile.c_str());
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # VoLum -- NAM Player
 
+<p align="center">
+  <img src="NeuralAmpModeler/resources/Images.xcassets/AppIcon.appiconset/iOSAppIcon.png" alt="VoLum app icon" width="160">
+</p>
+
 ![VoLum standalone UI](docs/volum-ui.png)
 
 A guitar amp collection player built on [Neural Amp Modeler](https://github.com/sdatkinson/NeuralAmpModelerPlugin). Ships 14 amp profiles with a custom UI for instant browsing and switching -- standalone app and VST3 plugin.


### PR DESCRIPTION
## Summary
- derive the selected rig filename during VoLum channel refresh so startup has the same current-rig state as later amp/channel switches
- initialize and refresh the footer from that cached filename so the UI no longer shows \`(no rig loaded)\` on first open when a rig is already selected
- add the VoLum app icon to the README header for project branding