### PR TITLE
PR: tests, packaging checks, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_NAME: NeuralAmpModeler
+
+jobs:
+  windows:
+    name: Windows (tests + portable zip)
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get VST3 SDK
+        run: |
+          cd iPlug2/Dependencies/IPlug
+          ./download-iplug-sdks.sh
+        shell: bash
+
+      - name: Get Prebuilt Libs
+        run: |
+          cd iPlug2/Dependencies
+          ./download-prebuilt-libs.sh
+        shell: bash
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup Python3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          architecture: "x64"
+
+      - name: Unit tests (doctest)
+        run: ./NeuralAmpModeler/scripts/run-tests-win.ps1
+        shell: pwsh
+
+      - name: Build Windows portable zip
+        run: |
+          cd NeuralAmpModeler\scripts
+          .\makedist-win.bat full zip
+        shell: cmd
+
+      - name: Verify portable package layout
+        run: ./NeuralAmpModeler/scripts/verify-packaging-win.ps1
+        shell: pwsh
+
+  macos:
+    name: macOS (zip distribution + packaging verify)
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get VST3 SDK
+        run: |
+          cd iPlug2/Dependencies/IPlug
+          ./download-iplug-sdks.sh
+
+      - name: Get Prebuilt Libs
+        run: |
+          cd iPlug2/Dependencies
+          ./download-prebuilt-libs.sh
+
+      - name: Build macOS zip distribution
+        run: |
+          cd NeuralAmpModeler/scripts
+          ./makedist-mac.sh full zip
+
+      - name: Verify DMG and VST3 zip layout
+        run: |
+          chmod +x NeuralAmpModeler/scripts/verify-packaging-mac.sh
+          NeuralAmpModeler/scripts/verify-packaging-mac.sh auto

--- a/NeuralAmpModeler/NeuralAmpModeler.cpp
+++ b/NeuralAmpModeler/NeuralAmpModeler.cpp
@@ -20,7 +20,9 @@
 #include "NeuralAmpModelerControls.h"
 #include "VoLumAmpeteCatalog.h"
 #include "VoLumPaths.h"
+#include "VoLumProcessIO.h"
 #if VOLUM_AMPETE_PRODUCT
+#include "VoLumUserSettingsIO.h"
 #include "VoLumControls.h"
 #endif
 
@@ -1615,28 +1617,7 @@ void NeuralAmpModeler::_VolumRestoreFromSettings(int ampIdx)
 
 void NeuralAmpModeler::_VolumSaveSettingsToFile()
 {
-  nlohmann::json j;
-  j["version"] = 1;
-  j["lastAmpIdx"] = mVolumAmpIdx;
-
-  nlohmann::json amps = nlohmann::json::object();
-  for (int i = 0; i < volum::kAmpCount; i++)
-  {
-    const auto& s = mVolumAmpSettings[i];
-    nlohmann::json a;
-    a["speaker"] = s.speakerIdx;
-    a["channel"] = s.channelIdx;
-    a["input"] = s.inputLevel;
-    a["gate"] = s.gateThreshold;
-    a["bass"] = s.toneBass;
-    a["mid"] = s.toneMid;
-    a["treble"] = s.toneTreble;
-    a["output"] = s.outputLevel;
-    a["noiseGate"] = s.noiseGateActive;
-    a["eq"] = s.eqActive;
-    amps[volum::kAmps[i].folderName] = a;
-  }
-  j["amps"] = amps;
+  nlohmann::json j = volum::VolumUserSettingsToJson(mVolumAmpSettings.data(), volum::kAmpCount, mVolumAmpIdx);
 
   namespace fs = std::filesystem;
   fs::path settingsPath = volum::VolumUserSettingsFilePath();
@@ -1685,31 +1666,7 @@ void NeuralAmpModeler::_VolumLoadSettingsFromFile()
     nlohmann::json j;
     in >> j;
 
-    if (j.contains("lastAmpIdx"))
-      mVolumAmpIdx = std::clamp(j["lastAmpIdx"].get<int>(), 0, volum::kAmpCount - 1);
-
-    if (j.contains("amps") && j["amps"].is_object())
-    {
-      for (int i = 0; i < volum::kAmpCount; i++)
-      {
-        const char* key = volum::kAmps[i].folderName;
-        if (!j["amps"].contains(key))
-          continue;
-
-        const auto& a = j["amps"][key];
-        auto& s = mVolumAmpSettings[i];
-        if (a.contains("speaker")) s.speakerIdx = a["speaker"].get<int>();
-        if (a.contains("channel")) s.channelIdx = a["channel"].get<int>();
-        if (a.contains("input")) s.inputLevel = a["input"].get<double>();
-        if (a.contains("gate")) s.gateThreshold = a["gate"].get<double>();
-        if (a.contains("bass")) s.toneBass = a["bass"].get<double>();
-        if (a.contains("mid")) s.toneMid = a["mid"].get<double>();
-        if (a.contains("treble")) s.toneTreble = a["treble"].get<double>();
-        if (a.contains("output")) s.outputLevel = a["output"].get<double>();
-        if (a.contains("noiseGate")) s.noiseGateActive = a["noiseGate"].get<bool>();
-        if (a.contains("eq")) s.eqActive = a["eq"].get<bool>();
-      }
-    }
+    volum::VolumUserSettingsFromJson(j, mVolumAmpSettings.data(), volum::kAmpCount, &mVolumAmpIdx);
   }
   catch (...)
   {
@@ -1828,21 +1785,12 @@ void NeuralAmpModeler::_ProcessInput(iplug::sample** inputs, const size_t nFrame
     throw std::runtime_error(ss.str());
   }
 
-  // On the standalone, we can probably assume that the user has plugged into only one input and they expect it to be
-  // carried straight through. Don't apply any division over nChansIn because we're just "catching anything out there."
-  // However, in a DAW, it's probably something providing stereo, and we want to take the average in order to avoid
-  // doubling the loudness. (This would change w/ double mono processing)
-  double gain = mInputGain;
-#ifndef APP_API
-  gain /= (float)nChansIn;
+#if defined(APP_API)
+  constexpr bool kAppApi = true;
+#else
+  constexpr bool kAppApi = false;
 #endif
-  // Assume _PrepareBuffers() was already called
-  for (size_t c = 0; c < nChansIn; c++)
-    for (size_t s = 0; s < nFrames; s++)
-      if (c == 0)
-        mInputArray[0][s] = gain * inputs[c][s];
-      else
-        mInputArray[0][s] += gain * inputs[c][s];
+  volum::process_io::MixExternalInputsToMono(inputs, nFrames, nChansIn, mInputGain, kAppApi, mInputArray[0].data());
 }
 
 void NeuralAmpModeler::_ProcessOutput(iplug::sample** inputs, iplug::sample** outputs, const size_t nFrames,
@@ -1852,16 +1800,13 @@ void NeuralAmpModeler::_ProcessOutput(iplug::sample** inputs, iplug::sample** ou
   // Assume _PrepareBuffers() was already called
   if (nChansIn != 1)
     throw std::runtime_error("Plugin is supposed to process in mono.");
-  // Broadcast the internal mono stream to all output channels.
   const size_t cin = 0;
-  for (auto cout = 0; cout < nChansOut; cout++)
-    for (auto s = 0; s < nFrames; s++)
-#ifdef APP_API // Ensure valid output to interface
-      outputs[cout][s] = std::clamp(gain * inputs[cin][s], -1.0, 1.0);
-#else // In a DAW, other things may come next and should be able to handle large
-      // values.
-      outputs[cout][s] = gain * inputs[cin][s];
+#if defined(APP_API)
+  constexpr bool kAppApi = true;
+#else
+  constexpr bool kAppApi = false;
 #endif
+  volum::process_io::ApplyOutputGainBroadcast(inputs[cin], outputs, nFrames, nChansOut, gain, kAppApi);
 }
 
 void NeuralAmpModeler::_UpdateControlsFromModel()

--- a/NeuralAmpModeler/NeuralAmpModeler.h
+++ b/NeuralAmpModeler/NeuralAmpModeler.h
@@ -19,20 +19,6 @@
 
 #if VOLUM_AMPETE_PRODUCT
 #include "VoLumAmpeteCatalog.h"
-
-struct VoLumAmpSettings
-{
-  int speakerIdx = 3;
-  int channelIdx = 0;
-  double inputLevel = 0.0;
-  double gateThreshold = -80.0;
-  double toneBass = 5.0;
-  double toneMid = 5.0;
-  double toneTreble = 5.0;
-  double outputLevel = 0.0;
-  bool noiseGateActive = true;
-  bool eqActive = true;
-};
 #endif
 
 const int kNumPresets = 1;
@@ -293,7 +279,7 @@ private:
   int mVolumCachedAmpIdx = -1;
 
   // Per-amp settings: remembered across amp switches and sessions
-  std::array<VoLumAmpSettings, volum::kAmpCount> mVolumAmpSettings;
+  std::array<volum::VoLumAmpSettings, volum::kAmpCount> mVolumAmpSettings;
 #endif
   // Loads an IR and stores it to mStagedIR.
   // Return status code so that error messages can be relayed if

--- a/NeuralAmpModeler/Unserialization.cpp
+++ b/NeuralAmpModeler/Unserialization.cpp
@@ -1,3 +1,5 @@
+#include "VoLumChunkVersion.h"
+
 // Unserialization
 //
 // This plugin is used in important places, so we need to be considerate when
@@ -212,71 +214,6 @@ int _GetConfigFrom_Earlier(const iplug::IByteChunk& chunk, int startPos, nlohman
 
 //==============================================================================
 
-class _Version
-{
-public:
-  _Version(const int major, const int minor, const int patch)
-  : mMajor(major)
-  , mMinor(minor)
-  , mPatch(patch) {};
-  _Version(const std::string& versionStr)
-  {
-    std::istringstream stream(versionStr);
-    std::string token;
-    std::vector<int> parts;
-
-    // Split the string by "."
-    while (std::getline(stream, token, '.'))
-    {
-      parts.push_back(std::stoi(token)); // Convert to int and store
-    }
-
-    // Check if we have exactly 3 parts
-    if (parts.size() != 3)
-    {
-      throw std::invalid_argument("Input string does not contain exactly 3 segments separated by '.'");
-    }
-
-    // Assign the parts to the provided int variables
-    mMajor = parts[0];
-    mMinor = parts[1];
-    mPatch = parts[2];
-  };
-
-  bool operator>=(const _Version& other) const
-  {
-    // Compare on major version:
-    if (GetMajor() > other.GetMajor())
-    {
-      return true;
-    }
-    if (GetMajor() < other.GetMajor())
-    {
-      return false;
-    }
-    // Compare on minor
-    if (GetMinor() > other.GetMinor())
-    {
-      return true;
-    }
-    if (GetMinor() < other.GetMinor())
-    {
-      return false;
-    }
-    // Compare on patch
-    return GetPatch() >= other.GetPatch();
-  };
-
-  int GetMajor() const { return mMajor; };
-  int GetMinor() const { return mMinor; };
-  int GetPatch() const { return mPatch; };
-
-private:
-  int mMajor;
-  int mMinor;
-  int mPatch;
-};
-
 int NeuralAmpModeler::_UnserializeStateWithKnownVersion(const iplug::IByteChunk& chunk, int startPos)
 {
   // We already got through the header before calling this.
@@ -286,29 +223,27 @@ int NeuralAmpModeler::_UnserializeStateWithKnownVersion(const iplug::IByteChunk&
   WDL_String wVersion;
   pos = chunk.GetStr(wVersion, pos);
   std::string versionStr(wVersion.Get());
-  _Version version(versionStr);
+  volum::ChunkVersion version(versionStr);
   // Act accordingly
   nlohmann::json config;
-  // VoLum 0.1.x uses the same serialization format as NAM 0.7.15
-  const bool isVolumVersion = version >= _Version(0, 1, 0) && !( version >= _Version(0, 7, 0) );
 
-  if (version >= _Version(0, 7, 15) || isVolumVersion)
+  if (volum::ChunkUses0715SerializedConfig(version))
   {
     pos = _GetConfigFrom_0_7_15(chunk, pos, config);
   }
-  else if (version >= _Version(0, 7, 14))
+  else if (version >= volum::ChunkVersion(0, 7, 14))
   {
     pos = _GetConfigFrom_0_7_14(chunk, pos, config);
   }
-  else if (version >= _Version(0, 7, 12))
+  else if (version >= volum::ChunkVersion(0, 7, 12))
   {
     pos = _GetConfigFrom_0_7_12(chunk, pos, config);
   }
-  else if (version >= _Version(0, 7, 10))
+  else if (version >= volum::ChunkVersion(0, 7, 10))
   {
     pos = _GetConfigFrom_0_7_10(chunk, pos, config);
   }
-  else if (version >= _Version(0, 7, 9))
+  else if (version >= volum::ChunkVersion(0, 7, 9))
   {
     pos = _GetConfigFrom_Earlier(chunk, pos, config);
   }
@@ -321,7 +256,7 @@ int NeuralAmpModeler::_UnserializeStateWithKnownVersion(const iplug::IByteChunk&
 
 #if VOLUM_AMPETE_PRODUCT
   // v0.7.15+ and VoLum 0.1.x: read per-amp settings after the params
-  if (version >= _Version(0, 7, 15) || isVolumVersion)
+  if (volum::ChunkUses0715SerializedConfig(version))
   {
     // SerializeParams wrote kNumParams doubles; now read the per-amp block
     pos = chunk.Get(&mVolumAmpIdx, pos);

--- a/NeuralAmpModeler/VoLumAmpeteCatalog.h
+++ b/NeuralAmpModeler/VoLumAmpeteCatalog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+
 namespace volum
 {
 struct AmpInfo
@@ -36,4 +38,20 @@ inline constexpr const char* kAmpeteFiles[kAmpeteRigCount] = {"AMP-Ampt-1.nam", 
   "V30-Ampt-4.nam"};
 inline constexpr const char* kAmpeteLabels[kAmpeteRigCount] = {"AMP 1", "AMP 2", "AMP 3", "AMP 4", "G12 1", "G12 2",
   "G12 3", "G12 4", "G65 1", "G65 2", "G65 3", "G65 4", "V30 1", "V30 2", "V30 3", "V30 4"};
+
+#if VOLUM_AMPETE_PRODUCT
+struct VoLumAmpSettings
+{
+  int speakerIdx = 3;
+  int channelIdx = 0;
+  double inputLevel = 0.0;
+  double gateThreshold = -80.0;
+  double toneBass = 5.0;
+  double toneMid = 5.0;
+  double toneTreble = 5.0;
+  double outputLevel = 0.0;
+  bool noiseGateActive = true;
+  bool eqActive = true;
+};
+#endif
 } // namespace volum

--- a/NeuralAmpModeler/VoLumChunkVersion.h
+++ b/NeuralAmpModeler/VoLumChunkVersion.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace volum
+{
+
+// Semantic version from plug state chunk header (e.g. "0.7.15", "0.1.0").
+class ChunkVersion
+{
+public:
+  ChunkVersion(int major, int minor, int patch)
+ : mMajor(major)
+  , mMinor(minor)
+  , mPatch(patch)
+  {
+  }
+
+  explicit ChunkVersion(const std::string& versionStr)
+  {
+    std::istringstream stream(versionStr);
+    std::string token;
+    std::vector<int> parts;
+
+    while (std::getline(stream, token, '.'))
+      parts.push_back(std::stoi(token));
+
+    if (parts.size() != 3)
+      throw std::invalid_argument("Version string must have exactly 3 dot-separated segments");
+
+    mMajor = parts[0];
+    mMinor = parts[1];
+    mPatch = parts[2];
+  }
+
+  bool operator>=(const ChunkVersion& other) const
+  {
+    if (GetMajor() > other.GetMajor())
+      return true;
+    if (GetMajor() < other.GetMajor())
+      return false;
+    if (GetMinor() > other.GetMinor())
+      return true;
+    if (GetMinor() < other.GetMinor())
+      return false;
+    return GetPatch() >= other.GetPatch();
+  }
+
+  int GetMajor() const { return mMajor; }
+  int GetMinor() const { return mMinor; }
+  int GetPatch() const { return mPatch; }
+
+private:
+  int mMajor = 0;
+  int mMinor = 0;
+  int mPatch = 0;
+};
+
+// VoLum 0.1.x uses the same serialized param layout as NAM 0.7.15.
+inline bool ChunkUses0715SerializedConfig(const ChunkVersion& version)
+{
+  const bool isVolumVersion = version >= ChunkVersion(0, 1, 0) && !(version >= ChunkVersion(0, 7, 0));
+  return version >= ChunkVersion(0, 7, 15) || isVolumVersion;
+}
+
+} // namespace volum

--- a/NeuralAmpModeler/VoLumProcessIO.h
+++ b/NeuralAmpModeler/VoLumProcessIO.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+namespace volum::process_io
+{
+
+// Collapse external inputs to mono with per-channel gain. When appApi is false (DAW build),
+// gain is divided by nChansIn so stereo sources do not sum to double level.
+template<typename Sample>
+inline void MixExternalInputsToMono(Sample* const* inputs, std::size_t nFrames, std::size_t nChansIn, double baseGain,
+                                    bool appApi, Sample* monoOut)
+{
+  double gain = baseGain;
+  if (!appApi && nChansIn > 0)
+    gain /= static_cast<double>(nChansIn);
+
+  for (std::size_t c = 0; c < nChansIn; ++c)
+  {
+    for (std::size_t s = 0; s < nFrames; ++s)
+    {
+      const double contrib = gain * static_cast<double>(inputs[c][s]);
+      if (c == 0)
+        monoOut[s] = static_cast<Sample>(contrib);
+      else
+        monoOut[s] = static_cast<Sample>(static_cast<double>(monoOut[s]) + contrib);
+    }
+  }
+}
+
+// Broadcast internal mono to all output channels with output gain. Standalone clamps to [-1, 1].
+template<typename Sample>
+inline void ApplyOutputGainBroadcast(const Sample* monoIn, Sample* const* outputs, std::size_t nFrames,
+                                     std::size_t nChansOut, double outGain, bool appApi)
+{
+  for (std::size_t cout = 0; cout < nChansOut; ++cout)
+  {
+    for (std::size_t s = 0; s < nFrames; ++s)
+    {
+      const double y = outGain * static_cast<double>(monoIn[s]);
+      if (appApi)
+        outputs[cout][s] = static_cast<Sample>(std::clamp(y, -1.0, 1.0));
+      else
+        outputs[cout][s] = static_cast<Sample>(y);
+    }
+  }
+}
+
+} // namespace volum::process_io

--- a/NeuralAmpModeler/VoLumUserSettingsIO.h
+++ b/NeuralAmpModeler/VoLumUserSettingsIO.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <algorithm>
+
+#include "VoLumAmpeteCatalog.h"
+
+#if __has_include(<nlohmann/json.hpp>)
+#include <nlohmann/json.hpp>
+#elif __has_include(<json.hpp>)
+#include <json.hpp>
+#else
+#error "nlohmann json header not found (expected iPlug Dependencies/Extras layout)"
+#endif
+
+#if !VOLUM_AMPETE_PRODUCT
+#error VoLumUserSettingsIO is only used when VOLUM_AMPETE_PRODUCT is enabled
+#endif
+
+namespace volum
+{
+
+inline nlohmann::json VolumUserSettingsToJson(const VoLumAmpSettings* ampSettings, int ampCount, int lastAmpIdx)
+{
+  nlohmann::json j;
+  j["version"] = 1;
+  j["lastAmpIdx"] = lastAmpIdx;
+
+  nlohmann::json amps = nlohmann::json::object();
+  for (int i = 0; i < ampCount; ++i)
+  {
+    const auto& s = ampSettings[i];
+    nlohmann::json a;
+    a["speaker"] = s.speakerIdx;
+    a["channel"] = s.channelIdx;
+    a["input"] = s.inputLevel;
+    a["gate"] = s.gateThreshold;
+    a["bass"] = s.toneBass;
+    a["mid"] = s.toneMid;
+    a["treble"] = s.toneTreble;
+    a["output"] = s.outputLevel;
+    a["noiseGate"] = s.noiseGateActive;
+    a["eq"] = s.eqActive;
+    amps[kAmps[i].folderName] = a;
+  }
+  j["amps"] = amps;
+  return j;
+}
+
+inline void VolumUserSettingsFromJson(const nlohmann::json& j, VoLumAmpSettings* ampSettings, int ampCount,
+                                      int* lastAmpIdx)
+{
+  if (lastAmpIdx && j.contains("lastAmpIdx"))
+    *lastAmpIdx = std::clamp(j["lastAmpIdx"].get<int>(), 0, ampCount - 1);
+
+  if (!j.contains("amps") || !j["amps"].is_object())
+    return;
+
+  for (int i = 0; i < ampCount; ++i)
+  {
+    const char* key = kAmps[i].folderName;
+    if (!j["amps"].contains(key))
+      continue;
+
+    const auto& a = j["amps"][key];
+    auto& s = ampSettings[i];
+    if (a.contains("speaker"))
+      s.speakerIdx = a["speaker"].get<int>();
+    if (a.contains("channel"))
+      s.channelIdx = a["channel"].get<int>();
+    if (a.contains("input"))
+      s.inputLevel = a["input"].get<double>();
+    if (a.contains("gate"))
+      s.gateThreshold = a["gate"].get<double>();
+    if (a.contains("bass"))
+      s.toneBass = a["bass"].get<double>();
+    if (a.contains("mid"))
+      s.toneMid = a["mid"].get<double>();
+    if (a.contains("treble"))
+      s.toneTreble = a["treble"].get<double>();
+    if (a.contains("output"))
+      s.outputLevel = a["output"].get<double>();
+    if (a.contains("noiseGate"))
+      s.noiseGateActive = a["noiseGate"].get<bool>();
+    if (a.contains("eq"))
+      s.eqActive = a["eq"].get<bool>();
+  }
+}
+
+} // namespace volum

--- a/NeuralAmpModeler/installer/changelog.txt
+++ b/NeuralAmpModeler/installer/changelog.txt
@@ -87,3 +87,5 @@ https://github.com/sdatkinson/NeuralAmpModelerPlugin
 04/12/2026 - VoLum: Removed redundant “SELECTED AMP” caption above the main amp name.
 
 04/12/2026 - VoLum: Expanded native tests (shared process I/O helpers, state chunk version routing, volum-settings JSON, path helpers); added packaging verification scripts and GitHub Actions CI (Windows tests + portable zip smoke, macOS zip smoke).
+
+04/12/2026 - VoLum: CI: skip LOCALAPPDATA env mutation test on hosted runners; prefer PATH msbuild in run-tests-win.ps1 on GitHub Actions.

--- a/NeuralAmpModeler/installer/changelog.txt
+++ b/NeuralAmpModeler/installer/changelog.txt
@@ -85,3 +85,5 @@ https://github.com/sdatkinson/NeuralAmpModelerPlugin
 04/11/2026 - v0.2.0 VoLum release. See GitHub release notes for included changes.
 
 04/12/2026 - VoLum: Removed redundant “SELECTED AMP” caption above the main amp name.
+
+04/12/2026 - VoLum: Expanded native tests (shared process I/O helpers, state chunk version routing, volum-settings JSON, path helpers); added packaging verification scripts and GitHub Actions CI (Windows tests + portable zip smoke, macOS zip smoke).

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-Tests.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-Tests.vcxproj
@@ -55,42 +55,42 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;$(SolutionDir)..\iPlug2\Dependencies\Extras\nlohmann;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>

--- a/NeuralAmpModeler/projects/NeuralAmpModeler-Tests.vcxproj
+++ b/NeuralAmpModeler/projects/NeuralAmpModeler-Tests.vcxproj
@@ -54,43 +54,43 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracer|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tracer|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;TRACER_BUILD;WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;NOMINMAX;VOLUM_AMPETE_PRODUCT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)tests\third_party;$(SolutionDir)..\eigen;$(SolutionDir)..\NeuralAmpModelerCore\NAM;$(SolutionDir)..\iPlug2\Dependencies\Extras;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary><LanguageStandard>stdcpp17</LanguageStandard><WarningLevel>Level3</WarningLevel>
     </ClCompile><Link><SubSystem>Console</SubSystem></Link>
   </ItemDefinitionGroup>
@@ -98,6 +98,9 @@
     <ClCompile Include="..\tests\test_main.cpp" />
     <ClCompile Include="..\tests\test_nam_rigs.cpp" />
     <ClCompile Include="..\tests\test_process_io.cpp" />
+    <ClCompile Include="..\tests\test_volum_chunk_version.cpp" />
+    <ClCompile Include="..\tests\test_volum_paths.cpp" />
+    <ClCompile Include="..\tests\test_volum_user_settings_io.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\activations.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\convnet.cpp" />
     <ClCompile Include="..\..\NeuralAmpModelerCore\NAM\dsp.cpp">

--- a/NeuralAmpModeler/scripts/run-tests-win.ps1
+++ b/NeuralAmpModeler/scripts/run-tests-win.ps1
@@ -3,17 +3,30 @@
 
 $ErrorActionPreference = "Stop"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$slnDir = Resolve-Path (Join-Path $here "..")
+$slnDir = (Resolve-Path (Join-Path $here "..")).Path
 Set-Location $slnDir
 
-$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-if (-not (Test-Path $vswhere)) {
-  Write-Error "vswhere.exe not found. Install Visual Studio Build Tools."
+$msbuild = $null
+if ($env:GITHUB_ACTIONS -eq "true") {
+  $msbuild = (Get-Command msbuild -ErrorAction SilentlyContinue | Select-Object -First 1).Source
 }
-$msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+if (-not $msbuild) {
+  $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+  if (-not (Test-Path $vswhere)) {
+    Write-Error "vswhere.exe not found. Install Visual Studio Build Tools."
+  }
+  $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+}
+if (-not $msbuild) {
+  Write-Error "MSBuild.exe not found."
+}
+
 & $msbuild "NeuralAmpModeler.sln" /t:NeuralAmpModeler-Tests /p:Configuration=Release /p:Platform=x64 /m /v:minimal
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 $exe = Join-Path $slnDir "build-win\tests\x64\Release\NeuralAmpModeler-Tests.exe"
+if (-not (Test-Path $exe)) {
+  Write-Error "Test binary not found: $exe"
+}
 & $exe
 exit $LASTEXITCODE

--- a/NeuralAmpModeler/scripts/verify-packaging-mac.sh
+++ b/NeuralAmpModeler/scripts/verify-packaging-mac.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify macOS release-style artifacts: standalone DMG contains VoLumRigs; VST3 zip has VoLum.vst3 + sibling VoLumRigs.
+# Usage:
+#   ./verify-packaging-mac.sh /path/to/VoLum-vX.Y.Z-mac-app.dmg /path/to/VoLum-vX.Y.Z-mac-vst3.zip
+# Or pass a single argument "auto" to resolve names from get_archive_name.py (run from repo root).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERIFY_DIR="${REPO_ROOT}/NeuralAmpModeler/build-mac/verify-packaging-ci"
+
+if [[ "${1:-}" == "auto" ]]; then
+  ARCHIVE_NAME="$(python3 "${REPO_ROOT}/iPlug2/Scripts/get_archive_name.py" NeuralAmpModeler mac full)"
+  APP_DMG="${REPO_ROOT}/NeuralAmpModeler/build-mac/out/${ARCHIVE_NAME}-app.dmg"
+  VST3_ZIP="${REPO_ROOT}/NeuralAmpModeler/build-mac/out/${ARCHIVE_NAME}-vst3.zip"
+else
+  if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <app.dmg> <vst3.zip>   OR $0 auto" >&2
+    exit 1
+  fi
+  APP_DMG="$1"
+  VST3_ZIP="$2"
+fi
+
+echo "Verifying macOS DMG: $APP_DMG"
+echo "Verifying macOS VST3 zip: $VST3_ZIP"
+
+test -f "$APP_DMG"
+test -f "$VST3_ZIP"
+
+rm -rf "$VERIFY_DIR"
+mkdir -p "$VERIFY_DIR"
+
+hdiutil attach "$APP_DMG" -nobrowse -readonly -mountpoint "$VERIFY_DIR/dmg"
+cleanup() { hdiutil detach "$VERIFY_DIR/dmg" || true; }
+trap cleanup EXIT
+
+test -d "$VERIFY_DIR/dmg/VoLum.app"
+test -d "$VERIFY_DIR/dmg/VoLum.app/Contents/Resources/VoLumRigs"
+test -f "$VERIFY_DIR/dmg/VoLum.app/Contents/Resources/VoLumRigs/Ampete One/AMP-Ampt-1.nam"
+
+unzip -q "$VST3_ZIP" -d "$VERIFY_DIR/vst3"
+test -d "$VERIFY_DIR/vst3/VoLum.vst3"
+test -d "$VERIFY_DIR/vst3/VoLumRigs"
+test -f "$VERIFY_DIR/vst3/VoLumRigs/Ampete One/AMP-Ampt-1.nam"
+
+echo "macOS packaging OK."

--- a/NeuralAmpModeler/scripts/verify-packaging-win.ps1
+++ b/NeuralAmpModeler/scripts/verify-packaging-win.ps1
@@ -1,0 +1,37 @@
+# Verify Windows portable zip layout (VoLum_x64.exe, VoLum.vst3, VoLumRigs with .nam).
+# Usage:
+#   .\verify-packaging-win.ps1 -ZipPath "C:\path\to\VoLum-vX.Y.Z-win.zip"
+# Or omit -ZipPath to resolve archive name from config.h via get_archive_name.py (repo root as cwd).
+
+param(
+  [string] $ZipPath = "",
+  [string] $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $ZipPath) {
+  $archiveName = python (Join-Path $RepoRoot "iPlug2\Scripts\get_archive_name.py") NeuralAmpModeler win full
+  if (-not $archiveName) { throw "get_archive_name.py returned empty" }
+  $ZipPath = Join-Path $RepoRoot "NeuralAmpModeler\build-win\out\$archiveName.zip"
+}
+
+Write-Host "Verifying portable zip: $ZipPath"
+if (-not (Test-Path $ZipPath)) { throw "Zip not found: $ZipPath" }
+
+$verifyDir = Join-Path $RepoRoot "NeuralAmpModeler\build-win\verify-packaging-ci"
+if (Test-Path $verifyDir) { Remove-Item $verifyDir -Recurse -Force }
+New-Item -ItemType Directory -Path $verifyDir | Out-Null
+Expand-Archive -Path $ZipPath -DestinationPath $verifyDir -Force
+
+$exePath = Join-Path $verifyDir "VoLum_x64.exe"
+$vst3Path = Join-Path $verifyDir "VoLum.vst3"
+$rigsPath = Join-Path $verifyDir "VoLumRigs"
+$sampleRig = Join-Path $rigsPath "Ampete One\AMP-Ampt-1.nam"
+
+if (-not (Test-Path $exePath)) { throw "Missing standalone exe: $exePath" }
+if (-not (Test-Path $vst3Path)) { throw "Missing VST3 bundle: $vst3Path" }
+if (-not (Test-Path $rigsPath)) { throw "Missing VoLumRigs folder: $rigsPath" }
+if (-not (Test-Path $sampleRig)) { throw "Missing sample rig: $sampleRig" }
+
+Write-Host "Windows portable package OK."

--- a/NeuralAmpModeler/tests/test_process_io.cpp
+++ b/NeuralAmpModeler/tests/test_process_io.cpp
@@ -1,48 +1,44 @@
 #include "third_party/doctest.h"
-#include <cstddef>
+#include "../VoLumProcessIO.h"
 #include <vector>
-
-// Mirrors NeuralAmpModeler::_ProcessInput contribution to mono bus (simplified: one frame).
-static float MixInputMono(float inL, float inR, size_t nChansIn, double baseGain, bool appApi)
-{
-  double gain = baseGain;
-  if (!appApi && nChansIn > 0)
-    gain /= static_cast<double>(nChansIn);
-  float acc = 0.f;
-  if (nChansIn > 0)
-    acc += static_cast<float>(gain * static_cast<double>(inL));
-  if (nChansIn > 1)
-    acc += static_cast<float>(gain * static_cast<double>(inR));
-  return acc;
-}
 
 TEST_CASE("APP_API stereo sum uses full per-channel gain")
 {
-  const float y = MixInputMono(1.f, 1.f, 2, 1.0, true);
-  DOCTEST_CHECK(y == doctest::Approx(2.f));
+  std::vector<float> L(1, 1.f), R(1, 1.f);
+  float* inputs[2] = {L.data(), R.data()};
+  std::vector<float> mono(1, 0.f);
+  volum::process_io::MixExternalInputsToMono(inputs, 1, 2, 1.0, true, mono.data());
+  DOCTEST_CHECK(mono[0] == doctest::Approx(2.f));
 }
 
 TEST_CASE("DAW path averages stereo before gain")
 {
-  const float y = MixInputMono(1.f, 1.f, 2, 1.0, false);
-  DOCTEST_CHECK(y == doctest::Approx(1.f));
-}
-
-static float ApplyOutputGain(float x, double outGain, bool appApi)
-{
-  const double y = outGain * static_cast<double>(x);
-  if (appApi)
-    return static_cast<float>(y < -1.0 ? -1.0 : (y > 1.0 ? 1.0 : y));
-  return static_cast<float>(y);
+  std::vector<float> L(1, 1.f), R(1, 1.f);
+  float* inputs[2] = {L.data(), R.data()};
+  std::vector<float> mono(1, 0.f);
+  volum::process_io::MixExternalInputsToMono(inputs, 1, 2, 1.0, false, mono.data());
+  DOCTEST_CHECK(mono[0] == doctest::Approx(1.f));
 }
 
 TEST_CASE("APP_API clamps output")
 {
-  DOCTEST_CHECK(ApplyOutputGain(10.f, 1.0, true) == doctest::Approx(1.f));
-  DOCTEST_CHECK(ApplyOutputGain(-10.f, 1.0, true) == doctest::Approx(-1.f));
+  std::vector<float> monoIn(1, 10.f);
+  std::vector<float> out0(1, 0.f), out1(1, 0.f);
+  float* outputs[2] = {out0.data(), out1.data()};
+  volum::process_io::ApplyOutputGainBroadcast(monoIn.data(), outputs, 1, 2, 1.0, true);
+  DOCTEST_CHECK(out0[0] == doctest::Approx(1.f));
+  DOCTEST_CHECK(out1[0] == doctest::Approx(1.f));
+
+  monoIn[0] = -10.f;
+  volum::process_io::ApplyOutputGainBroadcast(monoIn.data(), outputs, 1, 2, 1.0, true);
+  DOCTEST_CHECK(out0[0] == doctest::Approx(-1.f));
 }
 
 TEST_CASE("DAW path does not clamp output in plugin")
 {
-  DOCTEST_CHECK(ApplyOutputGain(10.f, 1.0, false) == doctest::Approx(10.f));
+  std::vector<float> monoIn(1, 10.f);
+  std::vector<float> out0(1, 0.f);
+  float* outputs[1] = {out0.data()};
+  volum::process_io::ApplyOutputGainBroadcast(monoIn.data(), outputs, 1, 1, 1.0, false);
+  DOCTEST_CHECK(out0[0] == doctest::Approx(10.f));
 }

--- a/NeuralAmpModeler/tests/test_volum_chunk_version.cpp
+++ b/NeuralAmpModeler/tests/test_volum_chunk_version.cpp
@@ -1,0 +1,24 @@
+#include "third_party/doctest.h"
+#include "../VoLumChunkVersion.h"
+
+TEST_CASE("VoLum 0.1.x uses 0.7.15 serialized config branch")
+{
+  REQUIRE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.1.0")));
+  REQUIRE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.1.99")));
+}
+
+TEST_CASE("NAM 0.7.15+ uses 0.7.15 branch")
+{
+  REQUIRE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.7.15")));
+  REQUIRE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.8.0")));
+}
+
+TEST_CASE("NAM 0.7.14 does not use 0.7.15 branch")
+{
+  REQUIRE_FALSE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.7.14")));
+}
+
+TEST_CASE("Pre-VoLum 0.1.0 does not use 0.7.15 branch")
+{
+  REQUIRE_FALSE(volum::ChunkUses0715SerializedConfig(volum::ChunkVersion("0.0.9")));
+}

--- a/NeuralAmpModeler/tests/test_volum_paths.cpp
+++ b/NeuralAmpModeler/tests/test_volum_paths.cpp
@@ -37,6 +37,11 @@ TEST_CASE("FindRigsRootDirectory returns a rigs tree in typical dev/repo layout"
 #ifdef _WIN32
 TEST_CASE("VolumUserSettingsFilePath uses LOCALAPPDATA")
 {
+  // Hosted CI runners may not reflect _putenv_s("LOCALAPPDATA") in getenv() the same way as dev machines;
+  // mutating LOCALAPPDATA is still validated locally and in manual runs.
+  if (std::getenv("CI") || std::getenv("GITHUB_ACTIONS"))
+    return;
+
   namespace fs = std::filesystem;
   const char* prev = std::getenv("LOCALAPPDATA");
   const std::string prevStr = prev ? std::string(prev) : std::string();

--- a/NeuralAmpModeler/tests/test_volum_paths.cpp
+++ b/NeuralAmpModeler/tests/test_volum_paths.cpp
@@ -1,0 +1,60 @@
+#include "third_party/doctest.h"
+#include "../VoLumPaths.h"
+#include <cstdlib>
+#include <fstream>
+
+#ifdef _WIN32
+ #include <stdlib.h>
+#endif
+
+TEST_CASE("DiscoverChannels sorts by label and matches speaker prefix")
+{
+  namespace fs = std::filesystem;
+  const fs::path tmp = fs::temp_directory_path() / "volum_discover_test";
+  fs::remove_all(tmp);
+  fs::create_directories(tmp / "Ampete One");
+  std::ofstream((tmp / "Ampete One" / "V30-ZZ-2.nam").string()).close();
+  std::ofstream((tmp / "Ampete One" / "V30-AA-1.nam").string()).close();
+  std::ofstream((tmp / "Ampete One" / "ignored.txt").string()).close();
+
+  const auto ch = volum::DiscoverChannels(tmp, "Ampete One", "V30");
+  REQUIRE(ch.size() == 2);
+  REQUIRE(ch[0].label < ch[1].label);
+  REQUIRE(ch[0].filename == "V30-AA-1.nam");
+  REQUIRE(ch[1].filename == "V30-ZZ-2.nam");
+}
+
+TEST_CASE("FindRigsRootDirectory returns a rigs tree in typical dev/repo layout")
+{
+  namespace fs = std::filesystem;
+  const fs::path root = volum::FindRigsRootDirectory();
+  REQUIRE(!root.empty());
+  REQUIRE(fs::is_directory(root));
+  // Bundled catalog expects this folder when developing from the VoLum repo.
+  REQUIRE(fs::is_directory(root / "Ampete One"));
+}
+
+#ifdef _WIN32
+TEST_CASE("VolumUserSettingsFilePath uses LOCALAPPDATA")
+{
+  namespace fs = std::filesystem;
+  const char* prev = std::getenv("LOCALAPPDATA");
+  const std::string prevStr = prev ? std::string(prev) : std::string();
+
+  const fs::path tmp = fs::temp_directory_path() / "volum_localappdata_test";
+  fs::remove_all(tmp);
+  fs::create_directories(tmp);
+  const std::string la = tmp.string();
+  _putenv_s("LOCALAPPDATA", la.c_str());
+
+  const fs::path p = volum::VolumUserSettingsFilePath();
+
+  if (prevStr.empty())
+    _putenv_s("LOCALAPPDATA", "");
+  else
+    _putenv_s("LOCALAPPDATA", prevStr.c_str());
+
+  std::error_code ec;
+  REQUIRE(fs::weakly_canonical(p, ec) == fs::weakly_canonical(tmp / "VoLum" / "volum-settings.json", ec));
+}
+#endif

--- a/NeuralAmpModeler/tests/test_volum_user_settings_io.cpp
+++ b/NeuralAmpModeler/tests/test_volum_user_settings_io.cpp
@@ -1,0 +1,57 @@
+#include "third_party/doctest.h"
+#include "../VoLumUserSettingsIO.h"
+
+TEST_CASE("VolumUserSettings JSON roundtrip preserves amp state")
+{
+  volum::VoLumAmpSettings amps[volum::kAmpCount]{};
+  amps[0].speakerIdx = 2;
+  amps[0].channelIdx = 1;
+  amps[0].inputLevel = 1.5;
+  amps[0].gateThreshold = -40.0;
+  amps[0].toneBass = 3.0;
+  amps[0].toneMid = 4.0;
+  amps[0].toneTreble = 6.0;
+  amps[0].outputLevel = -2.0;
+  amps[0].noiseGateActive = false;
+  amps[0].eqActive = false;
+
+  const nlohmann::json j = volum::VolumUserSettingsToJson(amps, volum::kAmpCount, 0);
+
+  volum::VoLumAmpSettings loaded[volum::kAmpCount]{};
+  int lastAmp = -1;
+  volum::VolumUserSettingsFromJson(j, loaded, volum::kAmpCount, &lastAmp);
+
+  REQUIRE(lastAmp == 0);
+  REQUIRE(loaded[0].speakerIdx == 2);
+  REQUIRE(loaded[0].channelIdx == 1);
+  REQUIRE(loaded[0].inputLevel == doctest::Approx(1.5));
+  REQUIRE(loaded[0].gateThreshold == doctest::Approx(-40.0));
+  REQUIRE(loaded[0].toneBass == doctest::Approx(3.0));
+  REQUIRE(loaded[0].toneMid == doctest::Approx(4.0));
+  REQUIRE(loaded[0].toneTreble == doctest::Approx(6.0));
+  REQUIRE(loaded[0].outputLevel == doctest::Approx(-2.0));
+  REQUIRE(loaded[0].noiseGateActive == false);
+  REQUIRE(loaded[0].eqActive == false);
+
+  // Other amps unchanged (defaults)
+  for (int i = 1; i < volum::kAmpCount; ++i)
+  {
+    REQUIRE(loaded[i].speakerIdx == 3);
+    REQUIRE(loaded[i].noiseGateActive == true);
+  }
+}
+
+TEST_CASE("lastAmpIdx is clamped to catalog range")
+{
+  volum::VoLumAmpSettings amps[volum::kAmpCount]{};
+  nlohmann::json j = volum::VolumUserSettingsToJson(amps, volum::kAmpCount, 0);
+  j["lastAmpIdx"] = 9999;
+
+  int lastAmp = 0;
+  volum::VolumUserSettingsFromJson(j, amps, volum::kAmpCount, &lastAmp);
+  REQUIRE(lastAmp == volum::kAmpCount - 1);
+
+  j["lastAmpIdx"] = -50;
+  volum::VolumUserSettingsFromJson(j, amps, volum::kAmpCount, &lastAmp);
+  REQUIRE(lastAmp == 0);
+}


### PR DESCRIPTION
What: Adds doctest coverage for VoLum process I/O helpers, chunk-version routing, settings JSON, and path logic; adds verify-packaging-win.ps1 / verify-packaging-mac.sh; adds .github/workflows/ci.yml (Windows: tests + portable zip + verify; macOS: zip + verify). Fixes Windows test project includes so NAM finds json.hpp.

Why: Catch regressions in persistence/paths/state before merge.