### PR TITLE
Lock agent planning on local .scratch

### DIFF
--- a/.cursor/rules/ai-artifact-authoring.mdc
+++ b/.cursor/rules/ai-artifact-authoring.mdc
@@ -24,6 +24,8 @@ Rank by delivery reliability per token spent, not by what is easiest to write.
    known *before* any file is touched: shell syntax, git remote, branch flow,
    "you run the builds". Every line here is paid in every session.
 5. **`AGENTS.md`** - routing index and command list. No detailed guidance.
+6. **`CONTEXT.md`** - glossary of product nouns, created lazily when a term is
+   actually resolved. Never a spec, never file paths, never feature plans.
 
 ## Anti-patterns
 

--- a/.cursor/rules/measure-twice-cut-once.mdc
+++ b/.cursor/rules/measure-twice-cut-once.mdc
@@ -7,8 +7,8 @@ alwaysApply: true
 
 ## Measure Twice: Plan Before Drafting
 
-For non-trivial or ambiguous work, prefer the `/grill-me` skill. Skip grilling
-for obvious single-step changes.
+For non-trivial or ambiguous work, prefer the `/grill-with-docs` skill. Skip
+grilling for obvious single-step changes.
 
 ## Cut Once: Implementation Handoff
 

--- a/.cursor/rules/vo-lum-workflow.mdc
+++ b/.cursor/rules/vo-lum-workflow.mdc
@@ -51,7 +51,11 @@ alwaysApply: true
 
 ## Scope discipline
 
-- Touch only files needed for the request. Do not add docs/README/ADRs unless asked.
+- Touch only files needed for the request.
+- Do not add product specs, README essays, or ADRs by default. An ADR is allowed
+  only when all three hold: hard to reverse, surprising without context, and the
+  result of a real trade-off. Product specs live in `.scratch/<effort>/` and are
+  deleted when the effort ships.
 
 ## Branching
 

--- a/.scratch/.gitkeep
+++ b/.scratch/.gitkeep
@@ -1,0 +1,2 @@
+# Keep this directory tracked. Per-effort maps/specs/tickets go in subdirs.
+# Conventions: docs/agents/issue-tracker.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,19 @@ Rules below auto-attach on the files they own; you do not need to open them by h
 - Upstream sync with NAMCore or NeuralAmpModelerPlugin: skill `upstream-sync`.
 - Writing or trimming rules/skills/`AGENTS.md`: `.cursor/rules/ai-artifact-authoring.mdc`.
 
+## Agent skills
+
+### Issue tracker
+
+Planning lives in tracked `.scratch/<effort>/` (maps, specs, tickets). Foggy
+multi-session work starts with `/wayfinder`. GitHub Issues stay user-facing.
+See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context. `CONTEXT.md` is a lazy glossary, not a spec. See
+`docs/agents/domain.md`.
+
 ## Fast Commands
 
 - Windows tests: `pwsh NeuralAmpModeler/scripts/run-tests-win.ps1`

--- a/backlog/README.md
+++ b/backlog/README.md
@@ -1,8 +1,8 @@
 # VoLum Backlog
 
-This folder holds planning prompts for open work. It is a tracked planning
-artifact: each open item below is a ready-to-paste prompt for a fresh Cursor
-planning chat.
+This folder is the **legacy** paste-prompt store. New planning goes in
+`.scratch/<effort>/` (see `docs/agents/issue-tracker.md`). Live prompts below
+stay until a `/wayfinder` session migrates them.
 
 **Only open work lives here.** When an item ships, delete its prompt file and add
 a one-line summary to the Done archive at the bottom. When an item ships
@@ -11,17 +11,19 @@ landed, so nobody re-plans shipped behaviour.
 
 ## How to use
 
-1. Pick one item. Open a fresh Cursor chat per item.
-2. Paste the prompt body into the chat.
-3. Let the planning session produce a scoped ticket
-   (problem, scope, acceptance criteria, tests/docs/changelog).
-4. Open a second chat to implement on the named feature branch.
-5. Merge back into `dev` once acceptance criteria are met.
+1. For a **new** foggy effort (e.g. 1.3.0 scope): fresh chat, `/wayfinder`,
+   destination first. Do not add files here.
+2. For one of the **live prompts below** until they migrate: paste into a fresh
+   chat, produce a scoped ticket, implement on `feature/<topic>`, merge to `dev`.
    Never promote to `main` outside of a release.
 
 ## Open items
 
-Verified against the code on 2026-07-30, not against the prompts' own claims.
+Verified against the code on 2026-08-27, not against the prompts' own claims.
+Nothing listed here fully shipped since the 2026-07-30 check (1.2.2 was a
+pitch-splice bugfix already covered by done `F1`; the 1.3.0 changelog line is
+splice CPU, not `F11`/`F12`).
+
 Items marked **partially shipped** have a status block at the top of the file
 naming what already exists.
 

--- a/docs/adr/0001-agent-planning-workflow.md
+++ b/docs/adr/0001-agent-planning-workflow.md
@@ -1,0 +1,13 @@
+# Local markdown planning tracker, lean docs
+
+Agent planning (wayfinder maps, specs, implementation tickets) lives in tracked
+`.scratch/<effort>/`, not GitHub Issues (those stay user-facing) and not new
+`backlog/` prompt files. Product specs are working memory: delete the
+`.scratch` effort when it ships. `CONTEXT.md` is created only when a product
+session actually resolves a term. ADRs only when the decision is hard to
+reverse, surprising without context, and the result of a real trade-off.
+
+**Considered options:** GitHub Issues for agent tickets (rejected: public
+process noise on a user-facing tracker); gitignored `.scratch/` (rejected: maps
+would not survive clone or the next machine); a fat always-loaded spec at repo
+root (rejected: it rots and pollutes every session).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,46 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when
+exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one
+  `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their
+absence; don't suggest creating them upfront. `/domain-modeling` (reached via
+`/grill-with-docs`) creates them lazily when terms or decisions actually get
+resolved.
+
+`CONTEXT.md` is a glossary of product nouns, not a spec. Do not put
+implementation, file paths, or feature plans in it.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md          ← lazy; create on first resolved term
+├── docs/adr/
+│   └── 0001-agent-planning-workflow.md
+└── NeuralAmpModeler/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor
+proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`.
+Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either
+you're inventing language the project doesn't use (reconsider) or there's a
+real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than
+silently overriding.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,49 @@
+# Issue tracker: Local Markdown
+
+Planning issues and specs for this repo live as markdown files in `.scratch/`.
+GitHub Issues stay for incoming user-facing bugs and requests. Do not publish
+wayfinder maps, grilling tickets, or agent implementation tickets there.
+
+`backlog/` is the legacy paste-prompt store. New planning goes here. Live
+backlog prompts remain until a wayfinder session migrates them.
+
+## Conventions
+
+- One effort per directory: `.scratch/<feature-slug>/`
+- The spec is `.scratch/<feature-slug>/spec.md`
+- Implementation issues are one file per ticket at
+  `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`, never a
+  single combined tickets file
+- Status is a `Status:` line near the top: `ready-for-agent`, `claimed`, or
+  `resolved`
+- Comments append under a `## Comments` heading
+- When the effort ships, delete `.scratch/<feature-slug>/`. Specs are working
+  memory, not always-loaded docs.
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if
+needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or
+the issue number directly.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `.scratch/<effort>/map.md` (the Notes / Decisions-so-far / Fog body).
+- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`,
+  with the question in the body. A `Type:` line records the ticket type
+  (`research`/`prototype`/`grilling`/`task`); a `Status:` line records
+  `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked
+  when every file it lists is `resolved`.
+- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open,
+  unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set
+  `Status: resolved`, then append a context pointer (gist + link) to the map's
+  Decisions-so-far in `map.md`.


### PR DESCRIPTION
## Summary

- Wire a local-markdown planning tracker at tracked `.scratch/<effort>/` so wayfinder/to-spec/to-tickets do not publish to public GitHub Issues.
- Retarget in-repo grilling to `/grill-with-docs`; ADRs only when hard-to-reverse, surprising, and a real trade-off; product specs prune when the effort ships.
- Mark `backlog/` as the legacy prompt store (re-verified 2026-08-27; no open item fully shipped) until a 1.3.0 wayfinder session migrates it.

## Occam / line counts

Repo agent corpus stayed small. This PR **adds** operational setup (`docs/agents/*`, ADR 0001, `.scratch/.gitkeep`) and a few routing lines; it does not slash glob rules.

| Artifact | Notes |
| --- | --- |
| `AGENTS.md` | + Agent skills routing block |
| `vo-lum-workflow.mdc` | ADR ban → 3-test gate + prune-when-shipped |
| `measure-twice-cut-once.mdc` | `/grill-me` → `/grill-with-docs` |
| `ai-artifact-authoring.mdc` | `CONTEXT.md` is a lazy glossary, never a spec |

Net this commit: **+144 / -13**.

## Global delete-or-slim (this machine, not in the PR)

Installed globally (`~/.agents/skills`, Cursor): `setup-matt-pocock-skills`, `grill-with-docs`, `grilling`, `domain-modeling`, `wayfinder`, `to-spec`, `to-tickets`, `ask-matt`.

Deleted stale/duplicate copies:

- `grill-me` from both `~/.agents/skills` and `~/.cursor/skills` (old one-question wrapper)
- `captain-hindsight` and `thermo-nuclear-code-quality-review` from `~/.agents/skills` (kept the `~/.cursor/skills` copies)

Left other-project globals (MMA, android, sales, etc.) untouched. Did not fork Pocock skills into this repo.

## Test plan

- [ ] Prose/config only; no C++ tests.
- [ ] Confirm `docs/agents/issue-tracker.md` and `docs/agents/domain.md` exist and `AGENTS.md` links them.
- [ ] Next session: fresh chat, `/wayfinder`, destination = 1.3.0 scope map in `.scratch/volum-1.3.0/`.